### PR TITLE
feat: Make it possible to enable debugMakeConnections()

### DIFF
--- a/src/GenericApp.cc
+++ b/src/GenericApp.cc
@@ -16,6 +16,11 @@ GenericApp::DeviceModuleGroup::DeviceModuleGroup(ctk::ModuleGroup* owner, std::s
 GenericApp::GenericApp() : Application("generic_chimeratk_server") {
   ChimeraTK::setDMapFilePath("devices.dmap");
 
+  if(std::getenv("GENERIC_SERVER_DEBUG_CONNECTIONS") != nullptr) {
+    debugMakeConnections();
+    ctk::Logger::getInstance().setMinSeverity(ctk::Logger::Severity::debug);
+  }
+
   auto& config = appConfig();
   std::vector<std::string> timers;
   try {


### PR DESCRIPTION
Use the environment variable GENERIC_SERVER_DEBUG_CONNECTIONS to enable
that, since it happens before we reach any control system interactions,
but on the other hand cannot properly hook into the command line for all
the adapters
